### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "source",
     "name_pretty": "Source Context",
-    "client_documentation": "https://googleapis.dev/python/source/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/source/latest",
     "issue_tracker": "http://github.com/googleapis/python-source-context/issues",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ This package contains generated Python types for `google.cloud.source_context_v1
    :target: https://pypi.org/project/google-cloud-source-context/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-source-context.svg
    :target: https://pypi.org/project/google-cloud-source-context/
-.. _Client Library Documentation: https://googleapis.dev/python/source/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/source/latest
 
 Installation
 ------------


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.