### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-### [1.2.3](https://github.com/googleapis/python-source-context/compare/v1.2.2...v1.2.3) (2022-05-05)
+## [1.2.3](https://github.com/googleapis/python-source-context/compare/v1.2.2...v1.2.3) (2022-05-05)
 
 
 ### Documentation
 
 * fix docstring for map fields ([614c640](https://github.com/googleapis/python-source-context/commit/614c640a224c6fcf0c1fd4656d871b3799508314))
 
-### [1.2.2](https://github.com/googleapis/python-source-context/compare/v1.2.1...v1.2.2) (2022-03-05)
+## [1.2.2](https://github.com/googleapis/python-source-context/compare/v1.2.1...v1.2.2) (2022-03-05)
 
 
 ### Bug Fixes
 
 * **deps:** require google-api-core>=1.31.5, >=2.3.2 ([#66](https://github.com/googleapis/python-source-context/issues/66)) ([0b06641](https://github.com/googleapis/python-source-context/commit/0b06641e0a648bdebf1539eaf12f666845795b80))
 
-### [1.2.1](https://www.github.com/googleapis/python-source-context/compare/v1.2.0...v1.2.1) (2021-11-01)
+## [1.2.1](https://www.github.com/googleapis/python-source-context/compare/v1.2.0...v1.2.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -48,21 +48,21 @@
 
 * bump release level to production/stable ([#31](https://www.github.com/googleapis/python-source-context/issues/31)) ([139188c](https://www.github.com/googleapis/python-source-context/commit/139188cb7a7850878b91756bacb0daf758cdcf2a))
 
-### [0.1.4](https://www.github.com/googleapis/python-source-context/compare/v0.1.3...v0.1.4) (2021-09-24)
+## [0.1.4](https://www.github.com/googleapis/python-source-context/compare/v0.1.3...v0.1.4) (2021-09-24)
 
 
 ### Bug Fixes
 
 * add 'dict' annotation type to 'request' ([0039f92](https://www.github.com/googleapis/python-source-context/commit/0039f92abf768992bdd79e68fb99407cd0e47629))
 
-### [0.1.3](https://www.github.com/googleapis/python-source-context/compare/v0.1.2...v0.1.3) (2021-08-23)
+## [0.1.3](https://www.github.com/googleapis/python-source-context/compare/v0.1.2...v0.1.3) (2021-08-23)
 
 
 ### Documentation
 
 * Migrate default branch to main ([#17](https://www.github.com/googleapis/python-source-context/issues/17)) ([6011f91](https://www.github.com/googleapis/python-source-context/commit/6011f91031abce8a71c5b6891a1ee8e241d580e0))
 
-### [0.1.2](https://www.github.com/googleapis/python-source-context/compare/v0.1.1...v0.1.2) (2021-07-29)
+## [0.1.2](https://www.github.com/googleapis/python-source-context/compare/v0.1.1...v0.1.2) (2021-07-29)
 
 
 ### Documentation
@@ -74,7 +74,7 @@
 
 * release as 0.1.2 ([#11](https://www.github.com/googleapis/python-source-context/issues/11)) ([1581f56](https://www.github.com/googleapis/python-source-context/commit/1581f56aae3879407e6b2d6de2012760f976deaf))
 
-### [0.1.1](https://www.github.com/googleapis/python-source-context/compare/v0.1.0...v0.1.1) (2021-07-21)
+## [0.1.1](https://www.github.com/googleapis/python-source-context/compare/v0.1.0...v0.1.1) (2021-07-21)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.